### PR TITLE
Update reference roles and add guest inheritance

### DIFF
--- a/resources/roles-reference.conf
+++ b/resources/roles-reference.conf
@@ -14,7 +14,6 @@ guest {
 user {
   name: User
   default: true
-  inherits: [ guest ]
   permissions: [
     board.lookup
     board.place
@@ -27,9 +26,23 @@ user {
   ]
 }
 
+developer {
+  name: Developer
+  badges: [
+    {
+      name: Developer
+      tooltip: Developer
+      type: icon
+      cssIcon: fas fa-wrench
+    }
+  ]
+  permissions: [
+    chat.usercolor.rainbow
+  ]
+}
+
 staff {
   name: Staff
-  inherits: [ user ]
   badges: [
     {
       name: Staff
@@ -40,49 +53,47 @@ staff {
   ]
   permissions: [
     board.check
-    board.cooldown.override
+    chat.usercolor.rainbow
+    user.admin
+    user.ratelimits.bypass
+    user.receivestaffbroadcasts
+  ]
+}
+
+trialmod {
+  name: Trial Moderator
+  inherits: [ staff ]
+  permissions: [
     chat.ban
     chat.delete
     chat.purge
-    chat.usercolor.rainbow
-    user.admin
     user.ban
+  ]
+}
+
+moderator {
+  name: Moderator
+  inherits: [ trialmod ]
+  permissions: [
+    board.cooldown.override
     user.namechange
     user.namechange.flag
     user.namechange.force
     user.permaban
-    user.ratelimits.bypass
-    user.receivestaffbroadcasts
-    user.shadowban
     user.unban
+  ]
+}
+
+administrator {
+  name: Administrator
+  inherits: [ moderator ]
+  permissions: [
+    user.shadowban
     faction.delete
     faction.edit
     faction.setblocked
     notification.create
     notification.discord
     notification.expired
-  ]
-}
-
-moderator {
-  name: Moderator
-  inherits: [ staff ]
-}
-
-administrator {
-  name: Administrator
-  inherits: [ moderator ]
-}
-
-developer {
-  name: Developer
-  inherits: [ administrator ]
-  badges: [
-    {
-      name: Developer
-      tooltip: Developer
-      type: icon
-      cssIcon: fas fa-wrench
-    }
   ]
 }

--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -16,6 +16,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class User {
     private int id;
@@ -186,7 +187,9 @@ public class User {
     }
 
     public boolean hasPermission(String node) {
-        if (roles.isEmpty()) return Role.getDefaultRoles().stream().anyMatch(role -> role.hasPermission(node));
+        if (roles.isEmpty()) return Stream.of(Role.getGuestRoles(), Role.getDefaultRoles())
+                .flatMap(Collection::stream)
+                .anyMatch(role -> role.hasPermission(node));
         return roles.stream().anyMatch(role -> role.hasPermission(node));
     }
 

--- a/src/main/java/space/pxls/util/HttpPermissionGate.java
+++ b/src/main/java/space/pxls/util/HttpPermissionGate.java
@@ -7,6 +7,7 @@ import space.pxls.App;
 import space.pxls.user.Role;
 import space.pxls.user.User;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -25,7 +26,9 @@ public class HttpPermissionGate implements HttpHandler {
         User user = exchange.getAttachment(AuthReader.USER);
         List<Role> roles = Role.getGuestRoles();
         if (user != null) {
-            roles = Stream.concat(user.getRoles().stream(), Role.getDefaultRoles().stream()).collect(Collectors.toList());
+            roles = Stream.of(user.getRoles(), Role.getGuestRoles(), Role.getDefaultRoles())
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList());
         }
         // Sanity check--if the user has no roles, assume guest again.
         if (roles.isEmpty()) roles = Role.getGuestRoles();


### PR DESCRIPTION
* Developers are no longer considered staff by default. They retain the ability to use a rainbow chat name.

* Added a Trial Moderator role.

* Moved most staff-based permissions to their relevant role (e.g. user.shadowban, all notification permissions to Administrator) rather than all on Staff. Basic staff-only permissions (such as mod checks, rate-limit bypassing, and receiving staff broadcasts) remain on Staff.

* By default, all visitors will inherit guest roles regardless of whether they are signed in.